### PR TITLE
Use new getDitcher act to obtain MongoDB client

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -88,7 +88,7 @@ var db = function (params, callback) {
   var CONST_CONN_STRING = "connectionString";
   if (!params.act) throw new Error("'act' undefined in params. See documentation of $fh.db for proper usage");
   // Type required for all but list operations, where we can list collections by omitting the type param
-  if (!(params.type) && ['close', 'list', 'export', 'import',CONST_CONN_STRING].indexOf(params.act) === -1) throw new Error("'type' undefined in params. See documentation of $fh.db for proper usage");
+  if (!(params.type) && ['close', 'list', 'export', 'getDitcher', 'import',CONST_CONN_STRING].indexOf(params.act) === -1) throw new Error("'type' undefined in params. See documentation of $fh.db for proper usage");
   if (!appname) throw new Error("Internal error - no appId defined");
 
   if (CONST_CONN_STRING  === params.act){

--- a/lib/sync-UpdatesModel_mongo.js
+++ b/lib/sync-UpdatesModel_mongo.js
@@ -3,7 +3,11 @@ var mongo;
 
 var setFHDB = function(db) {
   fhdb = db;
-  mongo = fhdb.getMongoClient();
+  db({
+    act: 'getDitcher'
+  }, function onGetClient(err, ditcher) {
+    mongo = ditcher.database.getMongoClient();
+  });
 };
 
 var create = function(dataset_id, data, cb) {


### PR DESCRIPTION
This will use the new `getDitcher` act in `fh-db` to set the `mongo`
value in `sync-UpdatesModel_mongo`. At the moment this is doing an
asynchronous call in `setFHDB` and it looks strange.

It may be better to wrap each function in a check for whether
`mongo` has been defined or not, if it's not it will do the
`getDitcher` act and then perform the MongoDB action.

This would ensure `mongo` is set on the first `create`, `list` or
`remove` invocation whereas at the moment there might be a chance
that `mongo` could still be undefined when the first invocation
occurs.